### PR TITLE
Allow relative URL in endpoint setting

### DIFF
--- a/src/AnalyticsPanel.tsx
+++ b/src/AnalyticsPanel.tsx
@@ -68,7 +68,7 @@ export class AnalyticsPanel extends PureComponent<Props> {
     if (isNew(location.pathname)) {
       const error = new Error('Dashboard is new and unsaved, and thus no ID was found.');
       this.setState({ error });
-    } else if (!isValidUrl(server)) {
+    } else if (!isValidUrl(server, location.origin)) {
       const error = new Error(`"${server}" is not a valid URL.`);
       this.setState({ error });
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,9 +27,9 @@ export function getTimestamp() {
   return unixFromMs(new Date().getTime());
 }
 
-export function isValidUrl(str: string) {
+export function isValidUrl(str: string, base?: string | URL | undefined) {
   try {
-    new URL(str);
+    new URL(str, base);
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
This makes it simpler when the backend is exposed on the same domain as
Grafana itself and allows avoiding having to hardcode the hostname in
panel definitions in dashboards.